### PR TITLE
Removing trailing comma  for metadata_args.context header field

### DIFF
--- a/ceramic-client/ceramic_python/model_instance_document.py
+++ b/ceramic-client/ceramic_python/model_instance_document.py
@@ -280,7 +280,7 @@ class ModelInstanceDocument:
             header["unique"] = b64encode(random_bytes).decode('utf-8')
 
         if metadata_args.context:
-            header["context"] = bytes(bytearray(list(base36_decode_with_prefix(metadata_args.context)))),
+            header["context"] = bytes(bytearray(list(base36_decode_with_prefix(metadata_args.context))))
 
         
         return {"data": content, "header": header}


### PR DESCRIPTION
Fixes an error caused by an accidental comma following the header["context"] field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a minor syntax issue in the context header construction, ensuring improved clarity and maintainability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->